### PR TITLE
Remove "Mis paradas" tab and add live line filter to Favoritas and Ce…

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,8 @@
     <main class="main">
         <div class="tabs">
             <button class="tab-btn active" data-index="0">Favoritas</button>
-            <button class="tab-btn" data-index="1">Mis paradas</button>
-            <button class="tab-btn" data-index="2">Cerca de mí</button>
-            <button class="tab-btn" data-index="3">Mapa</button>
+            <button class="tab-btn" data-index="1">Cerca de mí</button>
+            <button class="tab-btn" data-index="2">Mapa</button>
         </div>
 
         <div class="slider">
@@ -91,46 +90,23 @@
                         </div>
                     </section>
 
-                    <div id="favorites-stops"></div>
-                </section>
-
-                <!-- Slide 1: Mis paradas -->
-                <section class="slide accordion" data-slide="1">
-                    <section class="dynamic-controls">
-                        <div class="dynamic-title">Añadir otra parada</div>
-                        <form id="add-stop-form" class="dynamic-form">
-                            <label for="stop-id-input">Parada</label>
-                            <input
-                                    id="stop-id-input"
-                                    class="dynamic-input"
-                                    type="number"
-                                    inputmode="numeric"
-                                    placeholder="Ej: 1234"
-                            />
-                            <button type="submit" class="dynamic-button">Añadir</button>
-                        </form>
-                        <div class="dynamic-help">
-                            Se creará un nuevo acordeón con llegadas en tiempo real.
-                            Puedes ver la ubicación en mapa y la ruta andando desde Google Maps.
-                        </div>
-                    </section>
-
                     <div class="nearby-filter">
-                        <label for="my-line-input">Filtrar mis paradas por línea (opcional)</label>
+                        <label for="fav-line-input">Filtrar favoritas por línea (opcional)</label>
                         <input
-                                id="my-line-input"
+                                id="fav-line-input"
                                 class="nearby-line-input"
                                 type="text"
                                 inputmode="numeric"
-                                placeholder="Ej: 66, 137..."
+                                placeholder="Ej: 137"
                         />
+                        <div id="fav-filter-message" class="nearby-filter-message"></div>
                     </div>
 
-                    <div id="dynamic-stops"></div>
+                    <div id="favorites-stops"></div>
                 </section>
 
-                <!-- Slide 2: Paradas cercanas -->
-                <section class="slide accordion" data-slide="2">
+                <!-- Slide 1: Paradas cercanas -->
+                <section class="slide accordion" data-slide="1">
                     <section class="nearby-section">
                         <div class="nearby-title">
                             Paradas cercanas
@@ -142,18 +118,13 @@
 
                         <div class="nearby-filter">
                             <label for="nearby-line-input">Filtrar paradas cercanas por línea (opcional)</label>
-                            <div class="nearby-filter-row">
-                                <input
-                                        id="nearby-line-input"
-                                        class="nearby-line-input"
-                                        type="text"
-                                        inputmode="numeric"
-                                        placeholder="Ej: 66, 137..."
-                                />
-                                <button type="button" id="nearby-apply" class="nearby-filter-btn">
-                                    Aplicar
-                                </button>
-                            </div>
+                            <input
+                                    id="nearby-line-input"
+                                    class="nearby-line-input"
+                                    type="text"
+                                    inputmode="numeric"
+                                    placeholder="Ej: 137"
+                            />
                             <button type="button" id="nearby-clear" class="nearby-filter-clear">
                                 Quitar filtro
                             </button>
@@ -164,13 +135,12 @@
                     </section>
                 </section>
 
-                <!-- Slide 3: Mapa -->
-                <section class="slide" data-slide="3">
+                <!-- Slide 2: Mapa -->
+                <section class="slide" data-slide="2">
                     <div class="map-wrapper">
                         <div id="map" aria-label="Mapa de paradas"></div>
                         <div class="map-legend" aria-hidden="true">
                             <span class="map-legend-item"><span class="map-legend-dot map-legend-fav">★</span>Favorita</span>
-                            <span class="map-legend-item"><span class="map-legend-dot map-legend-dyn"></span>Mis paradas</span>
                             <span class="map-legend-item"><span class="map-legend-dot map-legend-near"></span>Cercana</span>
                             <span class="map-legend-item"><span class="map-legend-dot map-legend-user"></span>Tú</span>
                         </div>

--- a/js/apiEmt.js
+++ b/js/apiEmt.js
@@ -214,7 +214,7 @@ function normalizeLineLocal(l) {
     return String(l).trim().replace(/^0+/, "");
 }
 
-function getStopLinesFromRawStop(rawStop) {
+export function getStopLinesFromRawStop(rawStop) {
     if (!rawStop) return [];
 
     if (Array.isArray(rawStop.dataLine)) {
@@ -224,7 +224,16 @@ function getStopLinesFromRawStop(rawStop) {
     }
 
     if (Array.isArray(rawStop.lines)) {
-        return rawStop.lines.map(l => normalizeLineLocal(l));
+        return rawStop.lines
+            .map(l => {
+                if (l == null) return "";
+                // arroundxy devuelve a veces objetos { line, label, ... }
+                if (typeof l === "object") {
+                    return normalizeLineLocal(l.label || l.line || l.name || "");
+                }
+                return normalizeLineLocal(l);
+            })
+            .filter(Boolean);
     }
 
     if (typeof rawStop.lines === "string") {

--- a/js/main.js
+++ b/js/main.js
@@ -4,7 +4,9 @@ import {
     nearbyStopsCache,
     setNearbyStopsCache,
     isApiInCooldown,
-    setNearbyLineFilter
+    setNearbyLineFilter,
+    favoritesLineFilter,
+    setFavoritesLineFilter
 } from "./state.js";
 
 import {
@@ -17,11 +19,9 @@ import {
     setupAccordionListeners,
     refreshStop,
     renderNearbyStops,
-    createDynamicStopAccordion,
-    filterMyStopsByLine,
     renderFavorites,
-    renderDynamicStops,
-    handleAddFavorite
+    handleAddFavorite,
+    applyFavoritesFilter
 } from "./uiStops.js";
 
 import { initSlider } from "./slider.js";
@@ -50,20 +50,16 @@ function normalizeLine(l) {
 const globalStatusEl = document.getElementById("last-update-global");
 const refreshBtn      = document.getElementById("refresh-now");
 
-const addStopForm     = document.getElementById("add-stop-form");
-const stopIdInput     = document.getElementById("stop-id-input");
-
 const addFavoriteForm = document.getElementById("add-favorite-form");
 const favIdInput      = document.getElementById("fav-id-input");
 const favLinesInput   = document.getElementById("fav-lines-input");
 
 const nearbyStatusEl  = document.getElementById("nearby-status");
 const nearbyLineInput = document.getElementById("nearby-line-input");
-const nearbyApplyBtn  = document.getElementById("nearby-apply");
 const nearbyClearBtn  = document.getElementById("nearby-clear");
 const nearbyMsgEl     = document.getElementById("nearby-filter-message");
 
-const myLineInput     = document.getElementById("my-line-input");
+const favLineInput    = document.getElementById("fav-line-input");
 
 // --- Refresh paradas cercanas (wrapper con texto + cache) ---
 async function refreshNearbyStopsWrapper() {
@@ -133,10 +129,20 @@ async function refreshAll() {
         );
     }
 
-    // 3) Refrescar solo las paradas con acordeón abierto. Las cerradas se
-    //    refrescarán en el momento de abrirlas (ver header click handler).
-    const openStops = STOPS.filter(s => isStopAccordionOpen(s.id));
-    await Promise.all(openStops.map(stop => refreshStop(stop)));
+    // 3) Refrescar favoritas. Normalmente solo las que tienen el acordeón
+    //    abierto (las cerradas se refrescan al abrirlas). Pero si hay un filtro
+    //    por línea activo, refrescamos todas para poder decidir cuáles tienen
+    //    bus de esa línea y ocultar el resto.
+    const favFilter = favoritesLineFilter;
+    const favsToRefresh = favFilter
+        ? STOPS
+        : STOPS.filter(s => isStopAccordionOpen(s.id));
+    await Promise.all(
+        favsToRefresh.map(stop =>
+            refreshStop(favFilter ? { ...stop, filterLines: [favFilter] } : stop)
+        )
+    );
+    applyFavoritesFilter();
 
     // 4) Paradas cercanas
     await refreshNearbyStopsWrapper();
@@ -159,14 +165,13 @@ async function refreshAll() {
 setupAccordionListeners();              // No-op (compat); favoritas dinámicas se montan abajo
 renderShortcutsConfig();                // Config Casa/Trabajo en Favoritas
 renderFavorites();                      // Pinta favoritas desde localStorage
-renderDynamicStops(normalizeLine);      // Pinta Mis paradas desde localStorage
-initSlider();                           // Tabs + swipe
+initSlider();                           // Tabs
 
 // Procesar intents desde URL (?parada=NNNN o ?atajo=casa|trabajo)
 consumeUrlIntent({ toast });
 
 // Inicializar mapa la primera vez que se active su pestaña (lazy)
-const mapTabBtn = document.querySelector('.tab-btn[data-index="3"]');
+const mapTabBtn = document.querySelector('.tab-btn[data-index="2"]');
 if (mapTabBtn) {
     mapTabBtn.addEventListener("click", () => {
         ensureMapInitialized();
@@ -211,65 +216,27 @@ if (addFavoriteForm && favIdInput) {
     });
 }
 
-// Formulario "Mis paradas" (añadir parada)
-if (addStopForm && stopIdInput) {
-    addStopForm.addEventListener("submit", async (e) => {
-        e.preventDefault();
-        const raw = stopIdInput.value.trim();
-        if (!raw) return;
-
-        const stopId = parseInt(raw, 10);
-        if (Number.isNaN(stopId) || stopId <= 0) {
-            toast("Introduce un número de parada válido.", { type: "error" });
-            return;
-        }
-
-        await createDynamicStopAccordion(stopId, normalizeLine);
-        stopIdInput.value = "";
+// Filtro "Favoritas por línea" — en vivo (con debounce para no refrescar por tecla)
+if (favLineInput) {
+    let favFilterTimer = null;
+    favLineInput.addEventListener("input", () => {
+        setFavoritesLineFilter(normalizeLine(favLineInput.value.trim()));
+        applyFavoritesFilter();              // respuesta instantánea con lo ya conocido
+        clearTimeout(favFilterTimer);
+        favFilterTimer = setTimeout(() => refreshAll(), 500); // refina pidiendo llegadas
     });
 }
 
-// Filtro "Mis paradas por línea"
-if (myLineInput) {
-    myLineInput.addEventListener("input", () => {
-        filterMyStopsByLine(myLineInput.value.trim(), normalizeLine);
-    });
-}
-
-// Filtro "Paradas cercanas por línea" (aplicar / quitar)
-if (nearbyApplyBtn && nearbyLineInput) {
-    nearbyApplyBtn.addEventListener("click", () => {
-        const raw = nearbyLineInput.value.trim();
-
-        if (!raw) {
-            setNearbyLineFilter("");
-            if (nearbyMsgEl) nearbyMsgEl.textContent = "";
+// Filtro "Paradas cercanas por línea" — en vivo (con debounce)
+if (nearbyLineInput) {
+    let nearbyFilterTimer = null;
+    nearbyLineInput.addEventListener("input", () => {
+        setNearbyLineFilter(normalizeLine(nearbyLineInput.value.trim()));
+        if (nearbyMsgEl) nearbyMsgEl.textContent = "";
+        clearTimeout(nearbyFilterTimer);
+        nearbyFilterTimer = setTimeout(() => {
             renderNearbyStops(nearbyStopsCache);
-            return;
-        }
-
-        setNearbyLineFilter(normalizeLine(raw));
-
-        renderNearbyStops(nearbyStopsCache).then(() => {
-            let anyMatch = false;
-            document
-                .querySelectorAll("#nearby-accordion .bus-list")
-                .forEach(list => {
-                    if (
-                        list.children.length &&
-                        !list.children[0].classList.contains("empty")
-                    ) {
-                        anyMatch = true;
-                    }
-                });
-
-            if (!anyMatch && nearbyMsgEl) {
-                nearbyMsgEl.textContent =
-                    "No hay paradas cercanas con buses de esa línea ahora mismo.";
-            } else if (nearbyMsgEl) {
-                nearbyMsgEl.textContent = "";
-            }
-        });
+        }, 400);
     });
 }
 

--- a/js/map.js
+++ b/js/map.js
@@ -2,7 +2,6 @@
 
 import {
     FAVORITES,
-    DYNAMIC_STOPS,
     STOP_COORDS,
     nearbyStopsCache
 } from "./state.js";
@@ -31,11 +30,7 @@ function makeStopIcon(kind, symbol = "") {
 }
 
 function popupHtmlFor(stopId, kind, name) {
-    const kindLabel = kind === "fav"
-        ? "Favorita"
-        : kind === "dyn"
-            ? "Mis paradas"
-            : "Cercana";
+    const kindLabel = kind === "fav" ? "Favorita" : "Cercana";
     const safeName = name || `Parada ${stopId}`;
     return `
         <div class="map-popup">
@@ -59,9 +54,8 @@ function escapeHtml(s) {
 }
 
 function switchToTabAndOpenAccordion(stopId, kind) {
-    const tabIndex = kind === "fav" ? 0
-                   : kind === "dyn" ? 1
-                   : 2;
+    // fav → pestaña Favoritas (0); cualquier otra (cercana) → Cerca de mí (1)
+    const tabIndex = kind === "fav" ? 0 : 1;
     const tab = document.querySelector(`.tab-btn[data-index="${tabIndex}"]`);
     if (tab) tab.click();
 
@@ -149,21 +143,6 @@ export function refreshMapMarkers() {
         m.bindPopup(popupHtmlFor(fav.id, "fav", fav.label));
         m.addTo(markerLayer);
         placed.add(fav.id);
-        bounds.push([coords.lat, coords.lon]);
-    });
-
-    // Mis paradas
-    DYNAMIC_STOPS.forEach(s => {
-        if (placed.has(s.id)) return;
-        const coords = STOP_COORDS[s.id];
-        if (!coords) return;
-        const m = window.L.marker([coords.lat, coords.lon], {
-            icon: makeStopIcon("dyn"),
-            title: s.label || `Parada ${s.id}`
-        });
-        m.bindPopup(popupHtmlFor(s.id, "dyn", s.label));
-        m.addTo(markerLayer);
-        placed.add(s.id);
         bounds.push([coords.lat, coords.lon]);
     });
 

--- a/js/shortcuts.js
+++ b/js/shortcuts.js
@@ -1,7 +1,7 @@
 // shortcuts.js — atajos diarios (Casa / Trabajo) + manejo de URL params para
 // abrir directamente una parada (ya sea por id o por nombre del atajo).
 
-import { FAVORITES, DYNAMIC_STOPS, STOPS } from "./state.js";
+import { FAVORITES, STOPS } from "./state.js";
 
 const STORAGE_KEY = "greytux:shortcuts:v1";
 
@@ -136,7 +136,7 @@ export function renderShortcutsConfig(containerId = "shortcuts-config") {
     const container = document.getElementById(containerId);
     if (!container) return;
 
-    const allOptions = [...FAVORITES, ...DYNAMIC_STOPS];
+    const allOptions = [...FAVORITES];
     const optionsHtml = allOptions
         .map(s => {
             const label = s.label || `Parada ${s.id}`;

--- a/js/state.js
+++ b/js/state.js
@@ -52,47 +52,39 @@ function loadFavoritesFromStorage() {
 // Favoritas persistidas (las que viven en la pestaña "Favoritas")
 export const FAVORITES = loadFavoritesFromStorage();
 
-// "Mis paradas" persistidas (clave separada para no mezclar con favoritas)
-const DYNAMIC_STORAGE_KEY = "greytux:dynamic-stops:v1";
-
-function sanitizeDynamic(s) {
-    if (!s || !Number.isFinite(s.id)) return null;
-    const clean = { id: s.id };
-    if (typeof s.label === "string" && s.label.trim()) {
-        clean.label = s.label.trim();
-    }
-    return clean;
-}
-
-function loadDynamicStopsFromStorage() {
+// "Mis paradas" se ha unificado con Favoritas. Migración única: si quedan
+// paradas guardadas con el esquema antiguo, las incorporamos a favoritas y
+// borramos la clave vieja para no perder lo que el usuario tuviera ahí.
+(function migrateLegacyDynamicStops() {
+    const LEGACY_KEY = "greytux:dynamic-stops:v1";
     try {
-        const raw = localStorage.getItem(DYNAMIC_STORAGE_KEY);
-        if (!raw) return [];
+        const raw = localStorage.getItem(LEGACY_KEY);
+        if (!raw) return;
         const parsed = JSON.parse(raw);
-        if (!Array.isArray(parsed)) return [];
-        return parsed.map(sanitizeDynamic).filter(Boolean);
+        if (Array.isArray(parsed)) {
+            let changed = false;
+            parsed.forEach(s => {
+                const clean = sanitizeFavorite(s);
+                if (clean && !FAVORITES.some(f => f.id === clean.id)) {
+                    FAVORITES.push(clean);
+                    changed = true;
+                }
+            });
+            if (changed) persistFavorites();
+        }
+        localStorage.removeItem(LEGACY_KEY);
     } catch {
-        return [];
+        /* arranque resiliente: si la migración falla, seguimos */
     }
-}
+})();
 
-function persistDynamicStops() {
-    try {
-        localStorage.setItem(DYNAMIC_STORAGE_KEY, JSON.stringify(DYNAMIC_STOPS));
-    } catch (e) {
-        console.warn("No se pudo guardar Mis paradas en localStorage", e);
-    }
-}
-
-export const DYNAMIC_STOPS = loadDynamicStopsFromStorage();
-
-// Lista combinada que se usa para el polling. Se mantiene como referencia
-// estable para que los módulos que importan STOPS sigan funcionando.
+// Lista usada para el polling. Se mantiene como referencia estable para que
+// los módulos que importan STOPS sigan funcionando.
 export const STOPS = [];
 
 function syncStops() {
     STOPS.length = 0;
-    STOPS.push(...FAVORITES, ...DYNAMIC_STOPS);
+    STOPS.push(...FAVORITES);
 }
 syncStops();
 
@@ -148,25 +140,6 @@ export function setFavoriteCoords(id, lat, lon) {
     return true;
 }
 
-export function addDynamicStop(stop) {
-    const clean = sanitizeDynamic(stop);
-    if (!clean) return false;
-    if (STOPS.some(s => s.id === clean.id)) return false;
-    DYNAMIC_STOPS.push(clean);
-    persistDynamicStops();
-    syncStops();
-    return true;
-}
-
-export function removeDynamicStop(id) {
-    const i = DYNAMIC_STOPS.findIndex(s => s.id === id);
-    if (i === -1) return false;
-    DYNAMIC_STOPS.splice(i, 1);
-    persistDynamicStops();
-    syncStops();
-    return true;
-}
-
 // Coordenadas y líneas por parada
 export const STOP_COORDS = {};
 export const STOP_LINES  = {};
@@ -200,6 +173,12 @@ export function setNearbyStopsCache(stops) {
 export let nearbyLineFilter = "";
 export function setNearbyLineFilter(line) {
     nearbyLineFilter = line || "";
+}
+
+// Filtro actual de línea para favoritas
+export let favoritesLineFilter = "";
+export function setFavoritesLineFilter(line) {
+    favoritesLineFilter = line || "";
 }
 
 // ---- Alarmas (avísame cuando línea X esté a Y min en parada Z) ----

--- a/js/uiStops.js
+++ b/js/uiStops.js
@@ -1,17 +1,15 @@
 import {
     STOPS,
     FAVORITES,
-    DYNAMIC_STOPS,
     STOP_COORDS,
     STOP_LINES,
     nearbyLineFilter,
+    favoritesLineFilter,
     userLocation,
     addFavorite,
     removeFavorite,
     moveFavorite,
-    setFavoriteCoords,
-    addDynamicStop,
-    removeDynamicStop
+    setFavoriteCoords
 } from "./state.js";
 
 import { openCoordPicker } from "./coordPicker.js";
@@ -22,8 +20,15 @@ import { getDelayInfo } from "./etaTracker.js";
 
 import {
     getArrivals,
-    fetchStopCoords
+    fetchStopCoords,
+    getStopLinesFromRawStop
 } from "./apiEmt.js";
+
+// Normaliza el número de línea (quita ceros a la izquierda) para comparar.
+function normLine(l) {
+    if (l == null) return "";
+    return String(l).trim().replace(/^0+/, "");
+}
 
 import { toast, confirmDialog } from "./toast.js";
 
@@ -112,9 +117,8 @@ export function renderStop(stopConfig, arrivals) {
 
     let filtered = arrivals;
     if (filterLines && filterLines.length) {
-        filtered = arrivals.filter(a =>
-            filterLines.includes(String(a.line).trim())
-        );
+        const wanted = filterLines.map(normLine);
+        filtered = arrivals.filter(a => wanted.includes(normLine(a.line)));
     }
 
     let nextBusMinutes = null;
@@ -552,71 +556,73 @@ export async function renderNearbyStops(stops) {
     const nearbyAccordionEl = document.getElementById("nearby-accordion");
     if (!nearbyAccordionEl) return;
 
+    // Recordar qué acordeones estaban abiertos (antes de tocar el DOM)
     const prevOpenIds = new Set();
-    const prevItems = nearbyAccordionEl.querySelectorAll(".accordion-item.open");
-    prevItems.forEach(item => {
-        const id = item.dataset.stopId;
-        if (id) prevOpenIds.add(String(id));
+    nearbyAccordionEl.querySelectorAll(".accordion-item.open").forEach(item => {
+        if (item.dataset.stopId) prevOpenIds.add(String(item.dataset.stopId));
     });
 
-    nearbyAccordionEl.innerHTML = "";
-
-    if (!stops || !stops.length) {
+    const showMessage = (text) => {
+        nearbyAccordionEl.innerHTML = "";
         const div = document.createElement("div");
         div.className = "empty";
-        div.textContent = "Sin paradas cercanas en el radio seleccionado.";
+        div.textContent = text;
         nearbyAccordionEl.appendChild(div);
+    };
+
+    if (!stops || !stops.length) {
+        showMessage("Sin paradas cercanas en el radio seleccionado.");
         return;
     }
 
     const baseIds = new Set(STOPS.map(s => String(s.id)));
-
-    const filtered = stops
+    let candidates = stops
         .map(stop => {
             const stopId =
-                stop.stopId ??
-                stop.IdStop ??
-                stop.idStop ??
-                stop.id ??
-                stop.stopNum ??
-                null;
+                stop.stopId ?? stop.IdStop ?? stop.idStop ?? stop.id ?? stop.stopNum ?? null;
             return { raw: stop, stopId };
         })
         .filter(s => s.stopId != null && !baseIds.has(String(s.stopId)));
 
-    if (!filtered.length) {
-        const div = document.createElement("div");
-        div.className = "empty";
-        div.textContent = "Las paradas cercanas ya están entre tus paradas favoritas o añadidas.";
-        nearbyAccordionEl.appendChild(div);
+    if (!candidates.length) {
+        showMessage("Las paradas cercanas ya están entre tus favoritas.");
         return;
     }
 
-    const topN = filtered.slice(0, 34);
-    const stopConfigs = [];
+    const filterActive = !!nearbyLineFilter;
 
-    for (const { raw: stop, stopId } of topN) {
+    // Pre-filtro estático por líneas servidas: descartamos de entrada las
+    // paradas que no tienen la línea (ni se piden sus llegadas). Las de líneas
+    // desconocidas se mantienen y se deciden tras pedir las llegadas.
+    if (filterActive) {
+        candidates = candidates.filter(({ raw }) => {
+            const served = getStopLinesFromRawStop(raw);
+            return served.length === 0 || served.includes(nearbyLineFilter);
+        });
+        if (!candidates.length) {
+            showMessage(`Ninguna parada cercana tiene la línea ${nearbyLineFilter}.`);
+            return; // cero fetch, cero refresco
+        }
+    }
+
+    const topN = candidates.slice(0, 34);
+
+    // Cachear coords de las candidatas (barato, síncrono)
+    topN.forEach(({ raw, stopId }) => {
         const idNum = parseInt(stopId, 10);
-        const name =
-            stop.name ??
-            stop.stopName ??
-            stop.StopName ??
-            `Parada ${idNum}`;
-
-        if (stop.geometry && Array.isArray(stop.geometry.coordinates)) {
-            const coords = stop.geometry.coordinates;
-            const lon = parseFloat(coords[0]);
-            const lat = parseFloat(coords[1]);
+        if (raw.geometry && Array.isArray(raw.geometry.coordinates)) {
+            const lon = parseFloat(raw.geometry.coordinates[0]);
+            const lat = parseFloat(raw.geometry.coordinates[1]);
             if (!Number.isNaN(lat) && !Number.isNaN(lon)) {
                 STOP_COORDS[idNum] = { lat, lon };
             }
         }
+    });
 
-        const cfg = { id: idNum };
-        if (nearbyLineFilter) {
-            cfg.filterLines = [nearbyLineFilter];
-        }
+    const nameOf = (raw, idNum) =>
+        raw.name ?? raw.stopName ?? raw.StopName ?? `Parada ${idNum}`;
 
+    const buildArticle = (idNum, name, cfg, arrivals) => {
         const article = buildStopAccordionElement(cfg, {
             title: name,
             subtitle: `Parada ${idNum} · Cercana a tu ubicación`,
@@ -636,14 +642,95 @@ export async function renderNearbyStops(stops) {
                 }
             ]
         });
-
         nearbyAccordionEl.appendChild(article);
         updateLocationLink(idNum);
         renderAlarmsForStop(idNum);
-        stopConfigs.push(cfg);
+        if (arrivals !== undefined) renderStop(cfg, arrivals);
+    };
+
+    if (filterActive) {
+        // Fetch-first: pedimos llegadas y solo pintamos las paradas que tienen
+        // un bus de la línea ahora mismo. Sin acordeones vacíos ni parpadeo:
+        // el listado anterior permanece visible hasta tener los datos nuevos.
+        const results = await Promise.all(topN.map(async ({ raw, stopId }) => {
+            const idNum = parseInt(stopId, 10);
+            let arrivals = [];
+            try {
+                arrivals = await getArrivals(idNum);
+            } catch (e) {
+                /* ignoramos esta parada en este ciclo */
+            }
+            const has = arrivals.some(a =>
+                a.estimateArrive != null && normLine(a.line) === nearbyLineFilter
+            );
+            return { raw, idNum, arrivals, has };
+        }));
+
+        const visible = results.filter(r => r.has);
+        nearbyAccordionEl.innerHTML = "";
+        if (!visible.length) {
+            showMessage(
+                `No hay buses de la línea ${nearbyLineFilter} en paradas cercanas ahora mismo.`
+            );
+            return;
+        }
+        visible.forEach(({ raw, idNum, arrivals }) => {
+            const cfg = { id: idNum, filterLines: [nearbyLineFilter] };
+            buildArticle(idNum, nameOf(raw, idNum), cfg, arrivals);
+        });
+        return;
     }
 
+    // Sin filtro: comportamiento normal (construir todos + refrescar)
+    nearbyAccordionEl.innerHTML = "";
+    const stopConfigs = [];
+    for (const { raw, stopId } of topN) {
+        const idNum = parseInt(stopId, 10);
+        const cfg = { id: idNum };
+        buildArticle(idNum, nameOf(raw, idNum), cfg, undefined);
+        stopConfigs.push(cfg);
+    }
     await Promise.all(stopConfigs.map(cfg => refreshStop(cfg)));
+}
+
+// Aplica el filtro de línea de Favoritas: oculta las favoritas que no tienen
+// la línea (por líneas servidas conocidas) o que ahora mismo no muestran ningún
+// bus de esa línea. Se llama tras cada refresco y al teclear en el filtro.
+export function applyFavoritesFilter() {
+    const container = document.getElementById("favorites-stops");
+    if (!container) return;
+
+    const f = favoritesLineFilter;
+    const msgEl = document.getElementById("fav-filter-message");
+
+    if (!f) {
+        container.querySelectorAll(".accordion-item").forEach(a => {
+            a.style.display = "";
+        });
+        if (msgEl) msgEl.textContent = "";
+        return;
+    }
+
+    let anyVisible = false;
+    container.querySelectorAll(".accordion-item").forEach(article => {
+        const id = parseInt(article.dataset.stopId, 10);
+        const served = STOP_LINES[id];
+        let show;
+        if (Array.isArray(served) && served.length && !served.includes(f)) {
+            show = false; // la línea no pasa por esta parada
+        } else {
+            const busList = document.getElementById(`buses-${id}`);
+            show = !!(busList && busList.querySelector(".bus-item"));
+        }
+        article.style.display = show ? "" : "none";
+        if (show) anyVisible = true;
+    });
+
+    if (msgEl) {
+        msgEl.textContent = anyVisible
+            ? ""
+            : `Ninguna favorita con buses de la línea ${f} ahora mismo.`;
+    }
 }
 
 // ---- ACCORDIÓN ESTÁTICO (compat — ya no hay favoritas estáticas, pero se conserva por si acaso) ----
@@ -652,137 +739,5 @@ export function setupAccordionListeners() {
     // Mantenemos la función para que no rompa imports antiguos.
 }
 
-// ---- PARADAS DINÁMICAS ("Mis paradas") ----
-export function renderDynamicStops(normalizeLineFn) {
-    const container = document.getElementById("dynamic-stops");
-    if (!container) return;
-
-    // Mantener qué acordeones estaban abiertos
-    const prevOpen = new Set();
-    container.querySelectorAll(".accordion-item.open").forEach(item => {
-        if (item.dataset.stopId) prevOpen.add(item.dataset.stopId);
-    });
-
-    container.innerHTML = "";
-
-    if (!DYNAMIC_STOPS.length) {
-        return;
-    }
-
-    DYNAMIC_STOPS.forEach(stop => {
-        const wasOpen = prevOpen.size === 0 || prevOpen.has(String(stop.id));
-
-        const article = buildStopAccordionElement(stop, {
-            title: `Parada ${stop.id}`,
-            subtitle: `Número de parada ${stop.id}`,
-            open: wasOpen,
-            actions: [
-                {
-                    icon: "★",
-                    title: "Añadir a favoritas",
-                    onClick: async () => {
-                        const fav = { id: stop.id, label: `Parada ${stop.id}` };
-                        if (addFavorite(fav)) {
-                            // También quitarla de Mis paradas para no duplicar polling
-                            removeDynamicStop(stop.id);
-                            await renderFavorites();
-                            renderDynamicStops(normalizeLineFn);
-                            await refreshStop(fav);
-                            toast(`Parada ${stop.id} movida a favoritas.`, { type: "success" });
-                        } else {
-                            toast(`La parada ${stop.id} ya está en favoritas.`, { type: "warn" });
-                        }
-                    }
-                },
-                {
-                    icon: "✕",
-                    title: "Quitar de Mis paradas",
-                    danger: true,
-                    onClick: async () => {
-                        const ok = await confirmDialog(
-                            `¿Quitar la parada ${stop.id} de Mis paradas?`,
-                            { okText: "Quitar", danger: true }
-                        );
-                        if (!ok) return;
-                        removeDynamicStop(stop.id);
-                        renderDynamicStops(normalizeLineFn);
-                        toast(`Parada ${stop.id} quitada.`, { type: "success" });
-                    }
-                }
-            ]
-        });
-
-        container.appendChild(article);
-        updateLocationLink(stop.id);
-        renderAlarmsForStop(stop.id);
-    });
-
-    // Reaplicar filtro de línea si hay
-    const myLineInput = document.getElementById("my-line-input");
-    if (myLineInput && normalizeLineFn && myLineInput.value.trim()) {
-        filterMyStopsByLine(myLineInput.value.trim(), normalizeLineFn);
-    }
-}
-
-export async function createDynamicStopAccordion(stopId, normalizeLineFn) {
-    if (STOPS.some(s => s.id === stopId)) {
-        const existing = document.querySelector(
-            `.accordion-item[data-stop-id="${stopId}"]`
-        );
-        if (existing) {
-            existing.classList.add("open");
-        }
-        await refreshStop({ id: stopId });
-        return;
-    }
-
-    let arrivals;
-    try {
-        arrivals = await getArrivals(stopId);
-    } catch (err) {
-        console.error(err);
-        toast(
-            `No se ha podido obtener información para la parada ${stopId}. Comprueba el número.`,
-            { type: "error", duration: 5000 }
-        );
-        return;
-    }
-
-    const stopConfig = { id: stopId, label: `Parada ${stopId}` };
-    if (!addDynamicStop(stopConfig)) return;
-
-    try {
-        await fetchStopCoords(stopId);
-    } catch (e) {
-        console.warn("No se pudieron obtener coords para la parada dinámica", stopId);
-    }
-
-    // Re-render completo de Mis paradas (incluye la nueva), y aprovechamos
-    // los arrivals ya obtenidos para pintar inmediatamente la parada recién
-    // creada sin esperar otra llamada al endpoint.
-    renderDynamicStops(normalizeLineFn);
-    renderStop(stopConfig, arrivals);
-}
-
-// ---- Filtro "mis paradas" ----
-export function filterMyStopsByLine(filterVal, normalizeLineFn) {
-    const normalized = filterVal ? normalizeLineFn(filterVal) : "";
-    const dynamicStopsContainer = document.getElementById("dynamic-stops");
-    if (!dynamicStopsContainer) return;
-
-    const items = dynamicStopsContainer.querySelectorAll(".accordion-item");
-
-    items.forEach(item => {
-        const stopId = parseInt(item.dataset.stopId, 10);
-        if (!normalized) {
-            item.style.display = "";
-            return;
-        }
-        const lines = STOP_LINES[stopId] || [];
-        if (lines.some(l => l === normalized)) {
-            item.style.display = "";
-        } else {
-            item.style.display = "none";
-        }
-    });
-}
+// Las paradas se gestionan ahora únicamente desde Favoritas; "Mis paradas"
+// se ha eliminado para no duplicar funcionalidad (ver renderFavorites).

--- a/styles.css
+++ b/styles.css
@@ -649,10 +649,6 @@ h1 {
     margin-top: 4px;
 }
 
-#dynamic-stops {
-    margin-top: 10px;
-}
-
 .nearby-section {
     margin-top: 10px;
     padding: 10px 12px 12px;
@@ -895,7 +891,6 @@ h1 {
 }
 
 .map-legend-fav   { background: #f59e0b; }
-.map-legend-dyn   { background: #2563eb; }
 .map-legend-near  { background: #94a3b8; }
 .map-legend-user  { background: #ef4444; }
 
@@ -915,7 +910,6 @@ h1 {
 }
 
 .stop-marker-fav  { background: #f59e0b; }
-.stop-marker-dyn  { background: #2563eb; }
 .stop-marker-near { background: #94a3b8; }
 
 /* Popup del marker */

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // - NO cachea llamadas a la API EMT: deben ir siempre a red para no
 //   mostrar tiempos de bus rancios.
 
-const CACHE_VERSION = "turrobuses-shell-v8";
+const CACHE_VERSION = "turrobuses-shell-v10";
 const SHELL_ASSETS = [
     "./",
     "./index.html",


### PR DESCRIPTION
…rca de mí

Remove "Mis paradas":
- The tab duplicated Favoritas (both add a stop by ID). Drop the tab and slide, re-index the remaining tabs (Cerca de mí 1, Mapa 2), and delete the dynamic-stops system from state, uiStops, map and shortcuts.
- One-time migration folds any saved dynamic stops into favorites and clears the legacy localStorage key so nothing is lost.

Live line filter (both sections):
- Cerca de mí: pre-filter candidates by the lines each stop serves (from the arroundxy response) so stops without the line are never fetched. Fetch-first then render only stops that actually have a bus of that line right now — no empty accordions, no flicker. If no nearby stop serves the line, show a message and skip fetching entirely.
- Favoritas: when a filter is active, refresh all favorites (few) and hide those without a current bus of the line; instant response from known served lines, refined after fetching.
- Both filters apply live as you type (debounced). Drop the nearby "Aplicar" button.
- Export a more robust getStopLinesFromRawStop (handles lines as an array of objects) and normalise line numbers on both sides of the arrivals filter. Bump SW shell cache to v10.