### PR TITLE
Notify users when a new service worker version is available

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -313,11 +313,47 @@ if (document.visibilityState === "visible") {
     startPolling();
 }
 
-// Registro del service worker (PWA)
+// Registro del service worker (PWA) + aviso de versión nueva
 if ("serviceWorker" in navigator) {
-    window.addEventListener("load", () => {
-        navigator.serviceWorker
-            .register("./sw.js")
-            .catch(err => console.warn("SW no registrado:", err));
+    // Cuando el SW en espera toma el control, recargamos una sola vez para
+    // que la página corra ya con el código nuevo.
+    let reloading = false;
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+        if (reloading) return;
+        reloading = true;
+        window.location.reload();
+    });
+
+    const notifyUpdate = (worker) => {
+        if (!worker) return;
+        toast("Nueva versión disponible. Toca para actualizar.", {
+            type: "info",
+            sticky: true,
+            onClick: () => worker.postMessage({ type: "SKIP_WAITING" })
+        });
+    };
+
+    window.addEventListener("load", async () => {
+        try {
+            const reg = await navigator.serviceWorker.register("./sw.js");
+
+            // Si al registrar ya hay uno esperando y la página está controlada
+            // por un SW activo, es que hay versión nueva lista.
+            if (reg.waiting && navigator.serviceWorker.controller) {
+                notifyUpdate(reg.waiting);
+            }
+
+            reg.addEventListener("updatefound", () => {
+                const nw = reg.installing;
+                if (!nw) return;
+                nw.addEventListener("statechange", () => {
+                    if (nw.state === "installed" && navigator.serviceWorker.controller) {
+                        notifyUpdate(nw);
+                    }
+                });
+            });
+        } catch (err) {
+            console.warn("SW no registrado:", err);
+        }
     });
 }

--- a/js/toast.js
+++ b/js/toast.js
@@ -14,11 +14,17 @@ function ensureContainer() {
 }
 
 export function toast(message, options = {}) {
-    const { type = "info", duration = 3500 } = options;
+    const {
+        type = "info",
+        duration = 3500,
+        sticky = false,   // si true, no se cierra solo (hay que tocarlo)
+        onClick = null    // callback al tocar el toast (además de cerrarlo)
+    } = options;
     const c = ensureContainer();
 
     const el = document.createElement("div");
     el.className = `toast toast-${type}`;
+    if (onClick) el.classList.add("toast-action");
     el.setAttribute("role", type === "error" ? "alert" : "status");
     el.textContent = message;
     c.appendChild(el);
@@ -26,16 +32,25 @@ export function toast(message, options = {}) {
     // Activar transición en el siguiente frame
     requestAnimationFrame(() => el.classList.add("toast-visible"));
 
-    const timer = setTimeout(() => {
-        el.classList.remove("toast-visible");
-        setTimeout(() => el.remove(), 250);
-    }, duration);
-
-    el.addEventListener("click", () => {
-        clearTimeout(timer);
+    let timer = null;
+    const dismiss = () => {
+        if (timer) clearTimeout(timer);
         el.classList.remove("toast-visible");
         setTimeout(() => el.remove(), 200);
+    };
+
+    if (!sticky) {
+        timer = setTimeout(dismiss, duration);
+    }
+
+    el.addEventListener("click", () => {
+        if (onClick) {
+            try { onClick(); } catch (e) { console.warn("toast onClick error", e); }
+        }
+        dismiss();
     });
+
+    return dismiss;
 }
 
 export function confirmDialog(message, options = {}) {

--- a/styles.css
+++ b/styles.css
@@ -1118,6 +1118,16 @@ h1 {
 .toast.toast-success { background: #15803d; }
 .toast.toast-warn    { background: #b45309; }
 
+.toast.toast-action {
+    cursor: pointer;
+    border: 1px solid rgba(255,255,255,0.5);
+    font-weight: 600;
+}
+
+.toast.toast-action::after {
+    content: " ⟳";
+}
+
 /* ---- Coord picker (modal con mini-mapa Leaflet) ---- */
 .coord-picker-overlay {
     position: fixed;

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // - NO cachea llamadas a la API EMT: deben ir siempre a red para no
 //   mostrar tiempos de bus rancios.
 
-const CACHE_VERSION = "turrobuses-shell-v10";
+const CACHE_VERSION = "turrobuses-shell-v11";
 const SHELL_ASSETS = [
     "./",
     "./index.html",
@@ -24,10 +24,19 @@ const SHELL_ASSETS = [
 ];
 
 self.addEventListener("install", (event) => {
+    // No llamamos a skipWaiting() aquí: el nuevo SW queda "esperando" y la
+    // página avisa al usuario para que decida cuándo actualizar (ver el
+    // listener de mensajes SKIP_WAITING más abajo).
     event.waitUntil(
         caches.open(CACHE_VERSION).then((cache) => cache.addAll(SHELL_ASSETS))
     );
-    self.skipWaiting();
+});
+
+// La página manda este mensaje cuando el usuario toca "Actualizar".
+self.addEventListener("message", (event) => {
+    if (event.data && event.data.type === "SKIP_WAITING") {
+        self.skipWaiting();
+    }
 });
 
 self.addEventListener("activate", (event) => {


### PR DESCRIPTION
Switch the SW from auto-skipWaiting to a user-driven update flow:
- The new SW no longer calls skipWaiting() on install, so it parks in the "waiting" state instead of silently taking over. It skips waiting only when the page posts a SKIP_WAITING message.
- main.js listens for updatefound/statechange and, when a new worker is installed while an existing one controls the page, shows a sticky toast "Nueva versión disponible. Toca para actualizar." Tapping it messages the waiting worker; controllerchange then reloads the page once so it runs the new code.
- toast() gains `sticky` (no auto-dismiss) and `onClick` (action on tap) options, with a styled affordance for actionable toasts.
- Bump SW shell cache to v11.

Note: the notification only kicks in for updates after this version, since the currently-active SW predates the new flow.