### PR TITLE
Fix alarm form being wiped on refresh; tidy uiStops imports

### DIFF
--- a/js/alarms.js
+++ b/js/alarms.js
@@ -96,6 +96,14 @@ export function renderAlarmsForStop(stopId) {
     if (!container) return;
 
     const expanded = container.dataset.expanded === "true";
+
+    // No reconstruir mientras el usuario está escribiendo en el formulario:
+    // renderStop llama aquí en cada refresco (45 s) y rehacer el innerHTML
+    // borraría lo tecleado y robaría el foco.
+    if (expanded && container.contains(document.activeElement)) {
+        return;
+    }
+
     const alarms = getAlarmsForStop(stopId);
 
     container.innerHTML = "";

--- a/js/uiStops.js
+++ b/js/uiStops.js
@@ -24,18 +24,18 @@ import {
     getStopLinesFromRawStop
 } from "./apiEmt.js";
 
-// Normaliza el número de línea (quita ceros a la izquierda) para comparar.
-function normLine(l) {
-    if (l == null) return "";
-    return String(l).trim().replace(/^0+/, "");
-}
-
 import { toast, confirmDialog } from "./toast.js";
 
 import {
     evaluateAlarmsForStop,
     renderAlarmsForStop
 } from "./alarms.js";
+
+// Normaliza el número de línea (quita ceros a la izquierda) para comparar.
+function normLine(l) {
+    if (l == null) return "";
+    return String(l).trim().replace(/^0+/, "");
+}
 
 // --- Enlace "Ver ubicación" + "Ver ruta andando" ---
 function updateLocationLink(stopId) {


### PR DESCRIPTION
- renderAlarmsForStop is called from renderStop on every 45s refresh and rebuilt the section's innerHTML, so typing a new alarm while a refresh fired lost the input and focus. Skip the rebuild when focus is inside the alarms container.
- Move the toast and alarms imports in uiStops.js up to the top with the other imports (they were sitting mid-file after a function; worked via hoisting but was misleading).