### PR TITLE
Add QR scanner to add a stop to favorites from the camera

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,9 @@
                             />
                             <button type="submit" class="dynamic-button">Añadir</button>
                         </form>
+                        <button type="button" id="scan-qr-btn" class="scan-qr-btn">
+                            📷 Escanear QR de la parada
+                        </button>
                         <div class="dynamic-help">
                             Tus favoritas se guardan en este navegador. Puedes añadir, quitar o reordenar paradas.
                         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -40,6 +40,8 @@ import {
     consumeUrlIntent
 } from "./shortcuts.js";
 
+import { openQrScanner } from "./scanner.js";
+
 // Util para normalizar número de línea (quita ceros a la izquierda)
 function normalizeLine(l) {
     if (l == null) return "";
@@ -60,6 +62,7 @@ const nearbyClearBtn  = document.getElementById("nearby-clear");
 const nearbyMsgEl     = document.getElementById("nearby-filter-message");
 
 const favLineInput    = document.getElementById("fav-line-input");
+const scanQrBtn       = document.getElementById("scan-qr-btn");
 
 // --- Refresh paradas cercanas (wrapper con texto + cache) ---
 async function refreshNearbyStopsWrapper() {
@@ -212,6 +215,22 @@ if (addFavoriteForm && favIdInput) {
         if (ok) {
             favIdInput.value = "";
             if (favLinesInput) favLinesInput.value = "";
+        }
+    });
+}
+
+// Botón "Escanear QR de la parada"
+if (scanQrBtn) {
+    scanQrBtn.addEventListener("click", async () => {
+        const stopId = await openQrScanner();
+        if (stopId == null) return;
+
+        const ok = await handleAddFavorite(stopId, null);
+        if (ok) {
+            toast(`Parada ${stopId} añadida a favoritas.`, { type: "success" });
+            // Asegurar que estamos en la pestaña Favoritas para verla
+            const favTab = document.querySelector('.tab-btn[data-index="0"]');
+            if (favTab) favTab.click();
         }
     });
 }

--- a/js/scanner.js
+++ b/js/scanner.js
@@ -1,0 +1,208 @@
+// scanner.js — escáner de códigos QR de paradas EMT con la cámara.
+// Usa BarcodeDetector nativo donde existe (Android/Chrome) y cae a jsQR
+// (cargado bajo demanda desde CDN) en navegadores sin soporte (iPhone/Safari).
+
+const JSQR_URL = "https://unpkg.com/jsqr@1.4.0/dist/jsQR.js";
+
+let jsQrPromise = null;
+function loadJsQR() {
+    if (window.jsQR) return Promise.resolve(window.jsQR);
+    if (jsQrPromise) return jsQrPromise;
+    jsQrPromise = new Promise((resolve, reject) => {
+        const s = document.createElement("script");
+        s.src = JSQR_URL;
+        s.crossOrigin = "anonymous";
+        s.onload = () => resolve(window.jsQR);
+        s.onerror = () => {
+            jsQrPromise = null;
+            reject(new Error("No se pudo cargar el lector de QR."));
+        };
+        document.head.appendChild(s);
+    });
+    return jsQrPromise;
+}
+
+// Extrae el número de parada del contenido del QR. El QR de la EMT es una URL
+// tipo https://www.emtmadrid.es/PMVVisor/pmv.aspx?stopnum=2677&size=3
+export function parseStopIdFromQr(text) {
+    if (!text) return null;
+
+    // 1) URL con parámetro stopnum / stop / parada
+    try {
+        const u = new URL(text);
+        const sn =
+            u.searchParams.get("stopnum") ||
+            u.searchParams.get("stop") ||
+            u.searchParams.get("parada");
+        if (sn && /^\d+$/.test(sn)) return parseInt(sn, 10);
+    } catch {
+        /* no es una URL absoluta, seguimos con los patrones */
+    }
+
+    // 2) patrón stopnum=NNNN / parada=NNNN en texto suelto
+    const m =
+        text.match(/stop(?:num)?=(\d+)/i) ||
+        text.match(/parada[=/](\d+)/i);
+    if (m) return parseInt(m[1], 10);
+
+    // 3) primer número de hasta 5 dígitos como último recurso
+    const n = text.match(/\b(\d{1,5})\b/);
+    if (n) return parseInt(n[1], 10);
+
+    return null;
+}
+
+// Abre el modal de cámara y resuelve con el número de parada escaneado, o null
+// si el usuario cancela / no se pudo escanear.
+export function openQrScanner() {
+    return new Promise((resolve) => {
+        let stream = null;
+        let rafId = null;
+        let settled = false;
+        let detector = null;
+        let canvas = null;
+        let ctx = null;
+
+        const overlay = document.createElement("div");
+        overlay.className = "scanner-overlay";
+        overlay.innerHTML = `
+            <div class="scanner-modal" role="dialog" aria-modal="true" aria-label="Escanear QR de la parada">
+                <div class="scanner-header">
+                    <div class="scanner-title">Escanea el QR de la parada</div>
+                    <button type="button" class="scanner-close" aria-label="Cerrar">✕</button>
+                </div>
+                <div class="scanner-video-wrap">
+                    <video class="scanner-video" playsinline muted></video>
+                    <div class="scanner-frame"></div>
+                </div>
+                <div class="scanner-status">Apunta la cámara al código QR de la marquesina.</div>
+            </div>
+        `;
+
+        const video = overlay.querySelector(".scanner-video");
+        const statusEl = overlay.querySelector(".scanner-status");
+        const closeBtn = overlay.querySelector(".scanner-close");
+
+        const cleanup = () => {
+            if (rafId) cancelAnimationFrame(rafId);
+            rafId = null;
+            if (stream) {
+                stream.getTracks().forEach(t => t.stop());
+                stream = null;
+            }
+            document.removeEventListener("keydown", onKey);
+            overlay.classList.remove("scanner-visible");
+            setTimeout(() => overlay.remove(), 150);
+        };
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            resolve(result);
+        };
+
+        const onKey = (e) => {
+            if (e.key === "Escape") finish(null);
+        };
+
+        closeBtn.addEventListener("click", () => finish(null));
+        overlay.addEventListener("click", (e) => {
+            if (e.target === overlay) finish(null);
+        });
+        document.addEventListener("keydown", onKey);
+
+        const handleText = (text) => {
+            const stopId = parseStopIdFromQr(text);
+            if (stopId != null) {
+                finish(stopId);
+            } else {
+                statusEl.textContent = "QR leído pero sin número de parada reconocible.";
+            }
+        };
+
+        // Bucle de detección con BarcodeDetector nativo
+        const scanWithDetector = async () => {
+            if (settled) return;
+            try {
+                const codes = await detector.detect(video);
+                if (codes && codes.length) {
+                    handleText(codes[0].rawValue);
+                    if (settled) return;
+                }
+            } catch {
+                /* algunos frames fallan, seguimos */
+            }
+            rafId = requestAnimationFrame(scanWithDetector);
+        };
+
+        // Bucle de detección con jsQR (canvas)
+        const scanWithJsQr = (jsQR) => {
+            if (settled) return;
+            const w = video.videoWidth;
+            const h = video.videoHeight;
+            if (w && h) {
+                if (!canvas) {
+                    canvas = document.createElement("canvas");
+                    ctx = canvas.getContext("2d", { willReadFrequently: true });
+                }
+                canvas.width = w;
+                canvas.height = h;
+                ctx.drawImage(video, 0, 0, w, h);
+                const imageData = ctx.getImageData(0, 0, w, h);
+                const code = jsQR(imageData.data, w, h);
+                if (code && code.data) {
+                    handleText(code.data);
+                    if (settled) return;
+                }
+            }
+            rafId = requestAnimationFrame(() => scanWithJsQr(jsQR));
+        };
+
+        const startDecoding = async () => {
+            if ("BarcodeDetector" in window) {
+                try {
+                    detector = new window.BarcodeDetector({ formats: ["qr_code"] });
+                    scanWithDetector();
+                    return;
+                } catch {
+                    /* construirá falla → caemos a jsQR */
+                }
+            }
+            try {
+                statusEl.textContent = "Preparando el lector…";
+                const jsQR = await loadJsQR();
+                statusEl.textContent = "Apunta la cámara al código QR de la marquesina.";
+                scanWithJsQr(jsQR);
+            } catch (err) {
+                statusEl.textContent = err.message || "No se pudo iniciar el lector de QR.";
+            }
+        };
+
+        const start = async () => {
+            if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+                statusEl.textContent = "Este dispositivo no permite usar la cámara.";
+                return;
+            }
+            try {
+                stream = await navigator.mediaDevices.getUserMedia({
+                    video: { facingMode: { ideal: "environment" } },
+                    audio: false
+                });
+                video.srcObject = stream;
+                await video.play();
+                startDecoding();
+            } catch (err) {
+                console.warn("Cámara no disponible", err);
+                statusEl.textContent =
+                    err && err.name === "NotAllowedError"
+                        ? "Permiso de cámara denegado. Actívalo para escanear."
+                        : "No se pudo acceder a la cámara.";
+            }
+        };
+
+        document.body.appendChild(overlay);
+        requestAnimationFrame(() => overlay.classList.add("scanner-visible"));
+        start();
+    });
+}

--- a/styles.css
+++ b/styles.css
@@ -758,6 +758,117 @@ h1 {
     min-height: 14px;
 }
 
+/* ---- Botón escanear QR ---- */
+.scan-qr-btn {
+    margin-top: 8px;
+    width: 100%;
+    border: 1px solid #c7d2fe;
+    background: #eef2ff;
+    color: #1e3a8a;
+    border-radius: 999px;
+    padding: 8px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.scan-qr-btn:hover {
+    background: #e0e7ff;
+}
+
+.scan-qr-btn:active {
+    transform: translateY(1px);
+}
+
+/* ---- Modal del escáner QR ---- */
+.scanner-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15,23,42,0.75);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    z-index: 10002;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.scanner-overlay.scanner-visible {
+    opacity: 1;
+}
+
+.scanner-modal {
+    background: #ffffff;
+    border-radius: 14px;
+    width: 100%;
+    max-width: 420px;
+    padding: 14px 16px 16px;
+    box-shadow: 0 20px 48px rgba(0,0,0,0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.scanner-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.scanner-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #111827;
+}
+
+.scanner-close {
+    border: none;
+    background: transparent;
+    color: #6b7280;
+    font-size: 16px;
+    cursor: pointer;
+    padding: 4px;
+    line-height: 1;
+}
+
+.scanner-close:hover {
+    color: #111827;
+}
+
+.scanner-video-wrap {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    background: #020617;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.scanner-video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.scanner-frame {
+    position: absolute;
+    inset: 18%;
+    border: 3px solid rgba(255,255,255,0.9);
+    border-radius: 14px;
+    box-shadow: 0 0 0 100vmax rgba(0,0,0,0.25);
+    pointer-events: none;
+}
+
+.scanner-status {
+    font-size: 12px;
+    color: var(--muted);
+    text-align: center;
+    min-height: 16px;
+}
+
 /* ---- Atajos rápidos (Casa / Trabajo) ---- */
 #shortcuts-config {
     padding: 0 12px;

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // - NO cachea llamadas a la API EMT: deben ir siempre a red para no
 //   mostrar tiempos de bus rancios.
 
-const CACHE_VERSION = "turrobuses-shell-v11";
+const CACHE_VERSION = "turrobuses-shell-v12";
 const SHELL_ASSETS = [
     "./",
     "./index.html",
@@ -20,7 +20,8 @@ const SHELL_ASSETS = [
     "./js/coordPicker.js",
     "./js/walkTime.js",
     "./js/etaTracker.js",
-    "./js/shortcuts.js"
+    "./js/shortcuts.js",
+    "./js/scanner.js"
 ];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
- New scanner.js opens a camera modal and decodes the QR on EMT stop signage. Uses the native BarcodeDetector where available (Android/ Chrome) and lazy-loads jsQR from CDN as a fallback (iPhone/Safari).
- parseStopIdFromQr reads ?stopnum=NNNN from the stop URL, with fallbacks to stop=/parada= params and a bare number.
- "Escanear QR de la parada" button in the Favoritas add section; on a successful scan it calls handleAddFavorite, toasts, and switches to the Favoritas tab.
- Handles denied permission / no camera, and stops the camera stream on close. Bump SW shell cache to v12 (scanner.js added).

Note: the camera only works over HTTPS or localhost, so scanning a real stop from a phone needs the deployed (GitHub Pages) build.